### PR TITLE
fixing netlify refreshing issue when using react-router-dom

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+    from = "/*"
+    to = "/index.html"
+    status = 200


### PR DESCRIPTION
With these changes in place, your React Router-based application should handle route refreshes correctly on Netlify. When you refresh a page, Netlify's _redirects file ensures that the request is routed to your main entry point (index.html), where your React Router will take over and render the appropriate component for the requested route.